### PR TITLE
ci: Add release-please and conventional PR title enforcement

### DIFF
--- a/.github/workflows/conventional_pr_titles.yml
+++ b/.github/workflows/conventional_pr_titles.yml
@@ -1,0 +1,14 @@
+name: Conventional PR Titles
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+
+jobs:
+  pr-title-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: bluecanvas/action-semantic-pull-request@v5.5.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+# This workflow runs the 'release-please' bot.
+
+on:
+  push:
+    branches:
+      - master
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-24.04
+    steps:
+      # Run Bot
+      - id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: "@bluecanvas/sdk"
+          default-branch: master
+          release-type: node

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "types": "dist/index.d.ts",
   "author": "bluecanvas.io",
   "scripts": {
-    "bump": "npm --no-git-tag-version version patch",
-    "bump:pre": "npm --no-git-tag-version version preminor",
-    "bump:again": "npm --no-git-tag-version version prerelease",
-    "bump:complete": "npm --no-git-tag-version version minor",
-    "publish": "npm publish",
-    "publish:next": "npm publish --tag next",
     "clean": "rimraf dist types",
     "docs:gen": "rimraf docs && typedoc --plugin typedoc-plugin-markdown --excludePrivate --excludeProtected --hideBreadcrumbs --readme none --out docs",
     "prebuild": "npm run clean",


### PR DESCRIPTION
Remove manual version bump/publish scripts from package.json as release-please handles versioning automatically.